### PR TITLE
Fix AttributeError

### DIFF
--- a/LemonadeGui.py
+++ b/LemonadeGui.py
@@ -342,7 +342,7 @@ class LemonadeGui(GameEngineElement):
 
             # Text input, only handles numbers (ascii 48 - 58)
             elif event.key >= 48 and event.key <= 58:
-                key = str(event.str)
+                key = str(event.key - 48)
 
                 handle = self.__input_string[self.game_mode][
                             self.__input_mode[self.game_mode]]

--- a/LemonadeGui.py
+++ b/LemonadeGui.py
@@ -341,8 +341,8 @@ class LemonadeGui(GameEngineElement):
                     len(self.__input_keys[self.game_mode])
 
             # Text input, only handles numbers (ascii 48 - 58)
-            elif event.key >= 48 and event.key <= 58:
-                key = str(event.key - 48)
+            elif event.key >= ord('0') and event.key <= ord('9'):
+                key = str(event.key - ord('0'))
 
                 handle = self.__input_string[self.game_mode][
                             self.__input_mode[self.game_mode]]


### PR DESCRIPTION
Issue:
When pressing a number, it would throw an AttributeError, 'Event' object has no attribute 'str'

Solution:
Replace event.str with event.key -48

@chimosky @sourabhaa