### PR TITLE
fix bought amount display

### DIFF
--- a/LemonadeMain.py
+++ b/LemonadeMain.py
@@ -142,6 +142,7 @@ class LemonadeMain:
         # Process Item Payment
         for item in items:
             status = self.buy_item(item, items[item])
+            items[item] = status
             if status == -1:
                 self.add_msg(_("You can't afford any units of %s.") %
                              ITEMS[item]['name'])


### PR DESCRIPTION
Issue:
When trying to buy more items than you can afford, in the day's log it displayed the amount you tried to buy instead of the amount you actually bought

@chimosky @sourabhaa