### PR TITLE
Make window fit the screen

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -66,15 +66,15 @@ class VteActivity(activity.Activity):
         # now start subprocess.
         self._vte.connect('child-exited', self.on_child_exit)
         self._vte.grab_focus()
+        screen = Gdk.Screen.get_default()
+        screen_width = screen.get_width()
+        screen_height = screen.get_height()
         bundle_path = activity.get_bundle_path()
         self._pid = self._vte.spawn_sync(
-            Vte.PtyFlags.DEFAULT, bundle_path, [
-                '/bin/sh', '-c',
-                'python %s/LemonadeStand.py --width=1200 \
-                --height=900 --font=36' %
-                bundle_path], [
-                "PYTHONPATH=%s/library" %
-                bundle_path], GLib.SpawnFlags.DO_NOT_REAP_CHILD, None, None)
+        Vte.PtyFlags.DEFAULT, bundle_path, [
+            '/bin/sh', '-c',
+            'python %s/LemonadeStand.py --width=%d --height=%d --font=36' % (bundle_path, screen_width, screen_height)], [
+            "PYTHONPATH=%s/library" % bundle_path], GLib.SpawnFlags.DO_NOT_REAP_CHILD, None, None)
 
     def on_child_exit(self, widget, status):
         """This method is invoked when the user's script exits."""

--- a/fortuneengine/GameEngine.py
+++ b/fortuneengine/GameEngine.py
@@ -55,7 +55,7 @@ class GameEngine(object):
         self.width = width
         self.height = height
         size = width, height
-        self.screen = pygame.display.set_mode(size)
+        self.screen = pygame.display.set_mode(size, pygame.NOFRAME)
         pygame.display.set_caption(title)
         self.__fps = DrawableFontObject("", pygame.font.Font(None, 17))
         self.__fps.setPosition(0, 0)

--- a/fortuneengine/GameEngine.py
+++ b/fortuneengine/GameEngine.py
@@ -317,6 +317,7 @@ class GameEngine(object):
 
                     if retur_val:
                         break
+            pygame.display.flip()
 
     def stop_event_loop(self):
         """


### PR DESCRIPTION
Issue:
The pygame window that was created was fixed at 1200x900

Fix:
- Get Gtk's screen size and pass it's width and height to pygame.
- Make the pygame window that's created inside of GameEngine.py frameless in order to avoid hiding the bottom part of the pygame window.

Fixes #4

@chimosky @sourabhaa