### PR TITLE
Fix float buying amount

### DIFF
--- a/LemonadeMain.py
+++ b/LemonadeMain.py
@@ -255,7 +255,7 @@ class LemonadeMain:
         else:
             bulk_price = the_item['bulk'] * the_item['cost']
             # Lets try to buy as many as we can
-            can_buy = self.__resources['money'] / bulk_price
+            can_buy = self.__resources['money'] // bulk_price
 
             if can_buy != 0:
                 total = can_buy * the_item['bulk']


### PR DESCRIPTION
Reproduce:
With the starting amount of dollars try to buy 29 lemons. It should allow you to buy only 28 but, It allows you to buy 28.5714... lemons.

Fix:
Replacing true division with flour division in line 258 fixes the issue.

That's probably also a regression, @chimosky @sourabhaa, kindly review, thanks!